### PR TITLE
Some changes from Ben

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,5 @@ ln -s /path/to/repo/wp-dfp /path/to/wp-content/plugins/wp-dfp
 
 ### To work in your development environment:
 
-	$ gulp clean
-
-    $ gulp develop
-
-**NOTE:** The `clean` step is necessary before the `develop` step, in order to clean up the copied externals. It is necessary to run them in order separately (as opposed to simply making `clean` a dependency of `develop` in the Gulpfile,) due to a race-condition due to the asynchronous nature of gulp's task runner. Any effort to solve this bug would be greatly appreciated.
-
+  $ ./develop.sh
 

--- a/develop.sh
+++ b/develop.sh
@@ -6,5 +6,5 @@ npm install
 # Install / update all submodules
 git submodule update --recursive --init
 
-gulp clean
+# Watch SCSS files
 gulp develop

--- a/wp-dfp/wp-dfp-admin.php
+++ b/wp-dfp/wp-dfp-admin.php
@@ -374,8 +374,8 @@ class WP_DFP_Admin {
 	 * @return Modified $data.
 	 */
 	public static function insert_post_data( $data, $postarr ) {
-		if ( $postarr['post_type'] == WP_DFP::POST_TYPE && isset( $postarr['_wp_dfp_slot_name'] ) ) {
-			$data['post_name'] = sanitize_title_with_dashes( $postarr['_wp_dfp_slot_name'], '', 'save' );
+		if ( $postarr['post_type'] == WP_DFP::POST_TYPE && isset( $postarr['wp_dfp_slot_name'] ) ) {
+			$data['post_name'] = sanitize_title_with_dashes( $postarr['wp_dfp_slot_name'], '', 'save' );
 			$data['post_title'] = $postarr['wp_dfp_slot_name'];
 		}
 


### PR DESCRIPTION
- Simplify README to reflect simpler usage now that the "gulp clean" dependency has been resolved
- Use WP_Forms_API properly by defining forms in one place and processing the structure as a whole
- Correct array key on `$postarr` to actually exist so I can update the post name / title.
