### PR TITLE
Do not set $taxonomy in is_tax() block as a static method property,

### DIFF
--- a/wp-dfp/wp-dfp-frontend.php
+++ b/wp-dfp/wp-dfp-frontend.php
@@ -147,7 +147,7 @@ class WP_DFP_Frontend {
 		}
 		// Define targeting rules for custom taxonomy archives
 		elseif ( is_tax() ) {
-			self::$taxonomy = get_queried_object()->slug;
+			$taxonomy = get_queried_object()->slug;
 			self::$targeting['taxonomy'] = $taxonomy;
 			self::$targeting['term'] = get_query_var( $taxonomy );
 		}


### PR DESCRIPTION
## Summary

In the get_targeting() method in wp-dfp-frontend.php  the is_tax() conditional branch tries to set a value to self::$taxonomy which is not referenced anywhere else, the variable $taxonomy is used in the following lines to help set self::$targeting['taxonomy'] and self::$targeting['term']
## Relavant Ticket(s)

Brought to attention in https://thinkoomph.jira.com/browse/BCALLY-48
## Risk
- [ ] Trivial
- [x] Low
- [ ] Medium
- [ ] High
## How to Test
